### PR TITLE
Fix custom HTML example in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ new Tabit(
   document.getElementById('tabs'),
   {
     buttonSelector: '[data-target]',
-    contentSelector: 'data-target',
-    buttonAttribute: '[data-content]',
+    contentSelector: '[data-content]',
+    buttonAttribute: 'data-target',
     contentAttribute: 'data-content',  
   }
 );


### PR DESCRIPTION
Do this because the selector and attribute were swapped, and it took me quite a while to notice it.

Thanks for the great tool!